### PR TITLE
fix import on Ubuntu 15.10 python 3.5

### DIFF
--- a/docx2txt/__init__.py
+++ b/docx2txt/__init__.py
@@ -1,3 +1,3 @@
-from docx2txt import process
+from .docx2txt import process
 
 VERSION = '0.4'


### PR DESCRIPTION
I could not import the module successfully on Ubuntu 15.10 with python 3.5 . This change makes things work for me, hopefully they don't break something else.