### PR TITLE
Create MANIFEST.in w/ LICENSE.txt

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE.txt


### PR DESCRIPTION
I'm putting together [a build of `docx2txt`](https://github.com/conda-forge/staged-recipes/pull/1964) for [`conda`](conda.pydata.org) for [conda-forge](conda-forge.github.io). We'd like to link to hard copy of the license in the `meta.yaml` file, but that requires the license be bundled in the source distribution. By adding a `MANFEST.in` with this line, we guarantee that the license is bundled.