### PR TITLE
Update sys.stdout.write() for python 3.6.3.

### DIFF
--- a/bin/docx2txt
+++ b/bin/docx2txt
@@ -6,4 +6,4 @@ if __name__ == '__main__':
     import sys
     args = docx2txt.process_args()
     text = docx2txt.process(args.docx, args.img_dir)
-    sys.stdout.write(text.encode('utf-8'))
+    sys.stdout.buffer.write(text.encode('utf-8'))

--- a/docx2txt/docx2txt.py
+++ b/docx2txt/docx2txt.py
@@ -110,4 +110,4 @@ def process(docx, img_dir=None):
 if __name__ == '__main__':
     args = process_args()
     text = process(args.docx, args.img_dir)
-    sys.stdout.write(text.encode('utf-8'))
+    sys.stdout.buffer.write(text.encode('utf-8'))


### PR DESCRIPTION
Hey @ankushshah89, I encountered an error when running the script.  I'm running Python 3.6.3.

```
Traceback (most recent call last):
  File "./docx2txt.py", line 113, in <module>
    sys.stdout.write(text.encode('utf-8'))
TypeError: write() argument must be str, not bytes
```

The `sys.stdout.write()` function takes in a  `str` now instead of an utf-8 encoded `bytes`.  

To enforce `stdout` to write an utf-8 encoding (rather than the system default), we can just write to the `sys.stdout.buffer`, which can take an utf-8 encoded `bytes`.  That solved the bug.

 