### PR TITLE
add support for noBreakHyphen

### DIFF
--- a/docx2txt/docx2txt.py
+++ b/docx2txt/docx2txt.py
@@ -66,6 +66,8 @@ def xml2text(xml):
             text += '\n'
         elif child.tag == qn("w:p"):
             text += '\n\n'
+        elif child.tag == qn("w:noBreakHyphen"):
+            text += '-'
     return text
 
 


### PR DESCRIPTION
Currently `<w:noBreakHyphen />` just gets ignored by docx2txt. This change will replace it with a "-" instead.