### PR TITLE
Add code documentation for `process()`

### DIFF
--- a/docx2txt/docx2txt.py
+++ b/docx2txt/docx2txt.py
@@ -69,7 +69,24 @@ def xml2text(xml):
     return text
 
 
-def process(docx, img_dir=None):
+def process(docx: str, img_dir: str=None) -> str:
+    """Return all text extracted from the Word document located at the path `docx`. If `img_dir` is specified,
+    extract all images from the Word document and save in the directory `img_dir`.
+
+    Parameters
+    ----------
+    docx : str
+        The path to the Word document from which the text and images are to be extracted.
+
+    img_dir : str, default None
+        The path to a directory where the images extracted from the Word document will be written to.
+        If not specified, no images will be extracted.
+
+    Returns
+    -------
+    text : str
+        All the text extracted from the Word document.
+    """
     text = u''
 
     # unzip the docx in memory

--- a/docx2txt/docx2txt.py
+++ b/docx2txt/docx2txt.py
@@ -86,6 +86,14 @@ def process(docx: str, img_dir: str=None) -> str:
     -------
     text : str
         All the text extracted from the Word document.
+
+    Examples
+    --------
+    extract text
+    >>> text = docx2txt.process("file.docx")
+
+    extract text and write images in /tmp/img_dir
+    >>> text = docx2txt.process("file.docx", "/tmp/img_dir")
     """
     text = u''
 


### PR DESCRIPTION
I added docstrings and type annotations for the `process()` function to make it easier for users to figure out how exactly the package can be used to extract text and images.
Although documentation is provided in the README.md file in the package's GitHub repository, I think it's important that the code itself is documented as well so that users don't have to visit the repository to figure out how to use the package, which is the situation I found myself in.
It'll also help IDEs do code completion for developers using the package.