### PR TITLE
fix: Invalid dash-separated key 'description-file' in 'metadata'

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
Setup tool throwing error : 

`setuptools.errors.InvalidConfigError: Invalid dash-separated key 'description-file' in 'metadata' (setup.cfg), please use the underscore name 'description_file' instead.`

